### PR TITLE
update recent feed URLs

### DIFF
--- a/lib/MetaCPAN/SCORedirect.pm
+++ b/lib/MetaCPAN/SCORedirect.pm
@@ -467,11 +467,11 @@ sub rewrite {
       return [ 301,
           m{^/$}                        ? '/'
         : m{^/mirror(?:/.*)?$}          ? '/mirrors'
-        : m{^/uploads\.rdf(?:/.*)?}     ? '/feed/recent'
+        : m{^/uploads\.rdf(?:/.*)?}     ? '/recent.rdf'
         : m{^/faq\.html(?:/.*)?$}       ? '/about/faq'
         : m{^/feedback(?:/.*)?$}        ? '/about/contact'
         : m{^/pod2html(?:/.*)?$}        ? '/pod2html'
-        : m{^/rss/search\.rss$}         ? '/feed/recent?format=rss'
+        : m{^/rss/search\.rss$}         ? '/recent.rss'
         : return [ 404 ]
       ];
     }

--- a/t/redirects.t
+++ b/t/redirects.t
@@ -17,9 +17,9 @@ my @checks = (
   '/mirror'                                       => [ 301, 'https://metacpan.org/mirrors' ],
   '/mirror/guff'                                  => [ 301, 'https://metacpan.org/mirrors' ],
   '/mirror?guff'                                  => [ 301, 'https://metacpan.org/mirrors' ],
-  '/uploads.rdf'                                  => [ 301, 'https://metacpan.org/feed/recent' ],
-  '/uploads.rdf/guff'                             => [ 301, 'https://metacpan.org/feed/recent' ],
-  '/uploads.rdf?guff'                             => [ 301, 'https://metacpan.org/feed/recent' ],
+  '/uploads.rdf'                                  => [ 301, 'https://metacpan.org/recent.rdf' ],
+  '/uploads.rdf/guff'                             => [ 301, 'https://metacpan.org/recent.rdf' ],
+  '/uploads.rdf?guff'                             => [ 301, 'https://metacpan.org/recent.rdf' ],
   '/faq.html'                                     => [ 301, 'https://metacpan.org/about/faq' ],
   '/faq.html/guff'                                => [ 301, 'https://metacpan.org/about/faq' ],
   '/feedback'                                     => [ 301, 'https://metacpan.org/about/contact' ],
@@ -53,7 +53,7 @@ my @checks = (
   '/search?author=Moo'
     => [ 301, 'https://metacpan.org/search?q=Moo' ],
   '/search'                                       => [ 301, 'https://metacpan.org/' ],
-  '/rss/search.rss'                               => [ 301, 'https://metacpan.org/feed/recent?format=rss' ],
+  '/rss/search.rss'                               => [ 301, 'https://metacpan.org/recent.rss' ],
   '/rss/search.rss/guff'                          => [ 404 ],
 
   '/author/haarg'                                 => [ 301, 'https://metacpan.org/author/HAARG' ],


### PR DESCRIPTION
Update the uploads.rdf redirect to point to an end point that uses an RDF style rather than RSS style feed. This should fix CPAN.pm's use of the feed. Also update the other feed redirects to use MetaCPAN's new URLs.