### PR TITLE
automerge: tell gh command the repository

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,4 +24,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: gh pr merge --merge --auto "$PULL_REQUEST"
+          REPOSITORY: ${{ github.repository }}
+        run: gh pr merge -R "$REPOSITORY" --merge --auto "$PULL_REQUEST"


### PR DESCRIPTION
Without a checkout, gh needs to be told the repository.